### PR TITLE
Fix key F1 and key F3 in CentOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,16 @@ m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
 autom4te.cache
+
+# generated files
+
+Makefile
+config.log
+config.status
+doc/Makefile
+man/Makefile
+src/.deps/
+src/Makefile
+src/edit.o
+src/soedit
+

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ Many thanks to [Michael Ringgaard](https://github.com/ringgaard), the author, fo
 
 ## To install
 1. Download and extract the latest release tarball in a directory.
-2. In that directory, execute:
+2. Make sure that `autoconf` and `automake` are installed.
+3. In that directory, execute:
    ```bash
+   autoreconf -i
    ./configure
    make
    sudo make install

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.69])
+AC_PREREQ([2.63])
 AC_INIT([soedit], [1.0], [rajch@hotmail.com])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 # AC_CONFIG_SRCDIR([src/edit.c])

--- a/src/edit.c
+++ b/src/edit.c
@@ -825,6 +825,10 @@ int getkey() {
           if (ch == 0x31) {
             ch = getchar();
             switch (ch) {
+              case 0x31:
+                return getchar() == 0x7E ? KEY_F1 : KEY_UNKNOWN;
+              case 0x33:
+                return getchar() == 0x7E ? KEY_F3 : KEY_UNKNOWN;
               case 0x3B:
                 ch = getchar();
                 if (ch == 0x32) shift = 1;


### PR DESCRIPTION
`showkey -ascii` on my CentOS 6.10 showed different char codes for F1 and F3 keys than those used in edit.c so I've made some changes.

This is my `showkey` output for F1, F3, F5:

```
^[[11~   27 0033 0x1b
         91 0133 0x5b
         49 0061 0x31
         49 0061 0x31
        126 0176 0x7e
^[[13~   27 0033 0x1b
         91 0133 0x5b
         49 0061 0x31
         51 0063 0x33
        126 0176 0x7e
^[[15~   27 0033 0x1b
         91 0133 0x5b
         49 0061 0x31
         53 0065 0x35
        126 0176 0x7e
```

(above F5 codes were already in the code so didn't do anything about F5 key)

Also, I've lowered required version of `autoconf` because my CentOS 6.10 officialy supports only version 2.63.